### PR TITLE
fix: extend stake function

### DIFF
--- a/libs/defi/ogn/src/staking/components/ExtendAddLockupModal.tsx
+++ b/libs/defi/ogn/src/staking/components/ExtendAddLockupModal.tsx
@@ -128,7 +128,7 @@ export const ExtendAddLockupModal = ({
       contract: tokens.mainnet.xOGN,
       functionName: 'stake',
       args: [
-        totalAmount[0],
+        amountToAdd[0],
         durationSeconds,
         address ?? ZERO_ADDRESS,
         addRewards,


### PR DESCRIPTION
- The value input here should be the amount wanted to be added, not the total end amount of the lockup.

Added on some contract devs as they'll likely know what the input ought to be here.

That said - I've tested this with 2 transactions and things went as planned.